### PR TITLE
fix: make test cases use the published herald sql server

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,30 +7,17 @@ This is the REST-API application layer of the historischer-besiedlungszug.de web
 
 ## Configuration
 - `Rocket.toml`: The service uses Rocket's default configuration file. See its [Configuration Guide](https://rocket.rs/guide/v0.5/configuration/) for details.
-- `config.yaml`: Provided by the repository is the default generated config for running a Dolt SQL Server locally. The only purpose is that it doesn't have to be gitignored as it "feels strange" to gitignore a public non-dotfile configuration file.
 - `.env`: SQLx has a feature of compile-time checking queries and resolving to the actual data types. For that to work, the database URL has to be set. The local `.env` provides the defaults for the local environment and really shouldn't be changed unless you know exactly what you are doing.
 
 ## Dependencies
-### Binary Dependencies
-- [Rust](https://rust-lang.org/) (obviously)
-- [Dolt](https://www.dolthub.com/) for the database backend
+To run the test cases you need some kind of [Docker](https://www.docker.com) compatible runtime, the integration tests use the `DOCKER_HOST` environment variable to connect to a pipe. If setting up a test environment using [Podman](https://podman.io) make sure to set the environment variable accordingly and create the `herald` network beforehand.
 
-### Data Dependencies
-- [Herald](https://www.dolthub.com/repositories/besiedlungszug/herald)
-- [base32](https://www.dolthub.com/repositories/davidlokison/base32)
+If you also want to contribute to the [Herald Data Project](https://www.dolthub.com/repositories/besiedlungszug/herald), you need to install [Dolt](https://www.dolthub.com) and clone the repository. The `.gitignore` file is set up to exclude local dolt related files so that the data project can live in the same directory as the software project.
 
-To set up the database backend for contribution to this service, run the following commands from inside the repository:
-```sh
-dolt clone besiedlungszug/herald .
-dolt clone davidlokison/base32
-```
-
-The `.gitignore` file is set up to exclude local dolt related files so that the data project can live in the same directory as the software project.
+**Notice:** Currently, to add queries to the system, you also need to have a dolt sql server running. This currently can't be done with the Docker subsystem, so you need to install Dolt and the Herald data repository either way. This is bound to change before the first full release version.
 
 ## Contribution
-Contribution is highly welcome, whether by writing Issues or providing code. The Cargo framework should take care about most of the dependencies, but you need a local copy of the backend database service as well.
-
-To get the database running, you can run `dolt sql-server` from the project directory.
+Contribution is highly welcome, whether by writing Issues or providing code. You acknowledge that all contribution will be published under the same terms and conditions as this main repository.
 
 ## Legacy Codebase
 The old Python/FastAPI based approach has been moved over to the `legacy-python-fastapi` branch in case we would need any of it again later. The main reason to switch branches was for security and atomicity reasons, cause Rust provides hardened static typing and also compiles to a single binary for ease of deployment.

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -30,13 +30,7 @@ pub struct TestSuite {
 
 impl TestSuite {
     pub fn spawn() -> Self {
-        let sql_server = GenericBuildableImage::new("localhost/herald/dolt-sql-server", "latest")
-            .with_dockerfile_string(
-                r#"FROM dolthub/dolt-sql-server:1.84.0
-                RUN dolt clone --depth 1 besiedlungszug/herald"#
-            )
-            .build_image()
-            .unwrap()
+        let sql_server = GenericImage::new("besiedlungszug/herald-sql-server", "0.1.2")
             .with_wait_for(WaitFor::message_on_stdout("Ready for connections."))
             .with_network("herald")
             .with_env_var("DOLT_ROOT_HOST", "%")


### PR DESCRIPTION
Since we published [herald-sql-server](https://github.com/besiedlungszug/herald-sql-server) and pushed the first image to Docker Hub, there is no need for the locally-built test image any longer. Some time in the future, this technology would also be able to provide an environment for running the thing and writing queries.