### PR TITLE
refactor: clean up response structure

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -1,19 +1,19 @@
-use rocket::{Rocket, Build, Request, Responder, catch, catchers};
+use std::hash::Hash;
+
+use rocket::{Rocket, Build, Request, response::Responder, catch, catchers};
 use rocket::http::Status;
 use rocket::serde::json::Json;
 use rocket_db_pools::Database;
 use serde::Serialize;
 
-use herald::Error;
-
-pub type Result<T> = std::result::Result<HeraldResponseOk<T>, HeraldResponseErr>;
+pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Database)]
 #[database("herald")]
 pub struct Herald(sqlx::MySqlPool);
 
 #[catch(default)]
-pub fn default(status: Status, _req: &Request) -> HeraldResponseErr {
+pub fn default(status: Status, _req: &Request) -> Error {
     status.into()
 }
 
@@ -36,125 +36,121 @@ pub fn build() -> Rocket<Build> {
 macro_rules! expose_endpoint {
     ($(#[$meta:meta])* $name:ident $(,$arg:ident : $A:ty)*) => {
         $(#[$meta])*
-        async fn $name(mut db: rocket_db_pools::Connection<crate::core::Herald> $(,$arg: $A)*) -> std::result::Result<crate::core::HeraldResponseOk<impl serde::Serialize>, crate::core::HeraldResponseErr> {
-            herald::data::$name(&mut db $(,&$arg)*).await.map(Into::into).map_err(Into::into)
+        async fn $name(mut db: rocket_db_pools::Connection<crate::core::Herald> $(,$arg: $A)*) -> std::result::Result<crate::core::Custom<impl serde::Serialize>, crate::core::Error> {
+            let ret = herald::data::$name(&mut db $(,&$arg)*).await?;
+            crate::core::Custom::ok(ret)
         }
     };
 }
 
-pub fn wrap<T>(s: Status) -> impl Fn(T) -> (Status, T) {
-    move |v: T| (s, v)
+pub struct Created<T: Serialize + Hash> {
+    location: String,
+    data: T,
 }
 
-
-#[derive(Responder, Debug)]
-pub struct HeraldResponseOk<T>((Status, Json<HeraldResponseOkData<T>>));
-
-#[derive(Responder, Debug)]
-pub struct HeraldResponseErr((Status, Json<HeraldResponseErrData>));
-
 #[derive(Serialize, Debug)]
-struct HeraldResponseOkData<T> {
+pub struct Custom<T: Serialize> {
     status: Status,
     reason: &'static str,
     data: T,
 }
 
 #[derive(Serialize, Debug)]
-struct HeraldResponseErrData {
+pub struct Error {
     status: Status,
     reason: &'static str,
     error: String,
 }
 
-// HeraldResponseOk implementations
+// Created implementations
 
-impl<T> From<(Status, T)> for HeraldResponseOk<T> {
-    #[inline]
-    fn from((status, data): (Status, T)) -> Self {
-        Self((status, Json((status, data).into())))
+impl<T: Serialize + Hash> Created<T> {
+    fn new<S: Into<String>>(location: S, data: T) -> Self {
+        Self {
+            location: location.into(),
+            data: data,
+        }
+    }
+
+    pub fn ok<S: Into<String>>(location: S, data: T) -> Result<Self> {
+        Ok(Self::new(location, data))
     }
 }
 
-impl<T> From<T> for HeraldResponseOk<T> {
-    #[inline]
-    fn from(data: T) -> Self {
-        (Status::Ok, data).into()
+impl<'r, 'o: 'r, T: Serialize + Hash> Responder<'r, 'o> for Created<T> {
+    fn respond_to(self, req: &'r Request<'_>) -> rocket::response::Result<'o> {
+        let mut response = rocket::response::Response::build();
+        let created = rocket::response::status::Created::new(self.location).tagged_body(Json(&self.data));
+        response.merge(created.respond_to(req)?);
+        response.merge(Custom::new(Status::Created, self.data).respond_to(req)?);
+        response.ok()
     }
 }
 
-// HeraldResponseErr implementations
+// Custom implementations
 
-impl From<Status> for HeraldResponseErr {
-    #[inline]
-    fn from(status: Status) -> Self {
-        Self((status, Json(status.into())))
-    }
-}
-
-impl From<(Status, String)> for HeraldResponseErr {
-    #[inline]
-    fn from((status, error): (Status, String)) -> Self {
-        Self((status, Json((status, error).into())))
-    }
-}
-
-impl From<String> for HeraldResponseErr {
-    #[inline]
-    fn from(error: String) -> Self {
-        (Status::InternalServerError, error).into()
-    }
-}
-
-impl From<(Status, &str)> for HeraldResponseErr {
-    #[inline]
-    fn from((status, message): (Status, &str)) -> Self {
-        (status, message.to_string()).into()
-    }
-}
-
-impl From<Error> for HeraldResponseErr {
-    #[inline]
-    fn from(error: Error) -> Self {
-        (
-            match error {
-                Error::NotFound(_) => Status::NotFound,
-                Error::SqlxError(_) => Status::InternalServerError,
-            },
-            error.to_string(),
-        ).into()
-    }
-}
-
-// HeraldResponseOkData implementations
-
-impl<T> From<(Status, T)> for HeraldResponseOkData<T> {
-    #[inline]
-    fn from((status, data): (Status, T)) -> Self {
+impl<T: Serialize> Custom<T> {
+    fn new(status: Status, data: T) -> Self {
         Self {
             status: status,
             reason: status.reason_lossy(),
             data: data,
         }
     }
-}
 
-// HeraldResponseErrData implementations
-
-impl From<Status> for HeraldResponseErrData {
-    #[inline]
-    fn from(status: Status) -> Self {
-        (status, "".to_string()).into()
+    pub fn ok(data: T) -> Result<Self> {
+        Ok(Self::new(Status::Ok, data))
     }
 }
 
-impl From<(Status, String)> for HeraldResponseErrData {
+impl<'r, 'o: 'r, T: Serialize> Responder<'r, 'o> for Custom<T> {
     #[inline]
-    fn from((status, error): (Status, String)) -> Self {
+    fn respond_to(self, r: &'r Request<'_>) -> rocket::response::Result<'o> {
+        (self.status, Json(self)).respond_to(r)
+    }
+}
+
+// Error implementations
+
+impl Error {
+    fn new<S: Into<String>>(status: Status, error: S) -> Self {
         Self {
             status: status,
             reason: status.reason_lossy(),
-            error: error,
+            error: error.into(),
         }
+    }
+}
+
+impl From<Status> for Error {
+    #[inline]
+    fn from(status: Status) -> Self {
+        Self::new(status, "")
+    }
+}
+
+impl From<String> for Error {
+    #[inline]
+    fn from(error: String) -> Self {
+        Self::new(Status::InternalServerError, error)
+    }
+}
+
+impl From<herald::Error> for Error {
+    fn from(error: herald::Error) -> Self {
+        Self::new(
+            match error {
+                herald::Error::NotFound(_) => Status::NotFound,
+                herald::Error::SqlxError(_) => Status::InternalServerError,
+            },
+            error.to_string(),
+        )
+    }
+}
+
+impl<'r, 'o: 'r> Responder<'r, 'o> for Error {
+    #[inline]
+    fn respond_to(self, r: &'r Request<'_>) -> rocket::response::Result<'o> {
+        (self.status, Json(self)).respond_to(r)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,10 @@
 use rocket::{get, post, launch, routes};
-use rocket::http::Status;
 use rocket::serde::json::Json;
 use rocket_db_pools::Connection;
 use uuid::Uuid;
 
 mod core;
-use core::{Herald, Result, wrap};
+use core::{Herald, Result, Created, Custom};
 
 use herald::data;
 use herald::types::*;
@@ -17,27 +16,24 @@ expose_endpoint!(#[get("/events/open")] get_open_events);
 expose_endpoint!(#[get("/events/types")] get_event_types);
 
 #[get("/events/types/<event_type_slug>/items")]
-async fn get_bookable_items(mut db: Connection<Herald>, event_type_slug: &str) -> Result<Vec<Article>> {
+async fn get_bookable_items(mut db: Connection<Herald>, event_type_slug: &str) -> Result<Custom<Vec<Article>>> {
     let event_type_slug = EventTypeSlug::try_query(&mut **db, event_type_slug).await?;
     let articles = herald::data::get_bookable_items(&mut db, &event_type_slug).await?;
-    Ok(articles.into())
+    Custom::ok(articles)
 }
 
 #[get("/events/<event_id>/registrations/preview?<persons..>")]
-async fn get_registration_preview(mut db: Connection<Herald>, event_id: Uuid, persons: Vec<PriceCheck>) -> Result<impl serde::Serialize> {
+async fn get_registration_preview(mut db: Connection<Herald>, event_id: Uuid, persons: Vec<PriceCheck>) -> Result<Custom<Vec<Article>>> {
     let event_id = EventId::try_query(&mut **db, &event_id).await?;
-    herald::data::get_registration_preview(&mut db, &event_id, &persons).await
-        .map(Into::into)
-        .map_err(Into::into)
+    let preview = herald::data::get_registration_preview(&mut db, &event_id, &persons).await?;
+    Custom::ok(preview)
 }
 
 #[post("/events/<event_id>/registrations", data = "<registration>")]
-async fn create_registration(mut db: Connection<Herald>, event_id: Uuid, registration: Json<NewRegistration<'_>>) -> Result<()> {
+async fn create_registration(mut db: Connection<Herald>, event_id: Uuid, registration: Json<NewRegistration<'_>>) -> Result<Created<()>> {
     let event_id = EventId::try_query(&mut **db, &event_id).await?;
-    data::create_registration(&mut db, &event_id, &registration).await
-        .map(wrap(Status::Created))
-        .map(Into::into)
-        .map_err(Into::into)
+    let _ = data::create_registration(&mut db, &event_id, &registration).await?;
+    Created::ok("", ()) // TODO
 }
 
 #[launch]


### PR DESCRIPTION
I have taken the liberty to clean up the response structure of the binary part of Herald... since there is some implications of special response codes I wanted to provide a way to also return empty responses and such. Now we roughly mirror the structure of Rocket's status wrappers and the response types of path handlers are more explicit.