### PR TITLE
feat: add automatic build pipeline workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,22 @@
+name: Rust
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v6
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Build
         run: cargo build --locked --verbose
       - name: Clean Project
-        run: cargo clean --locked --project=${{ needs.get-project-name.outputs.name }}
+        run: cargo clean --locked --package=${{ needs.get-project-name.outputs.name }}
   test:
     name: Test Binary
     needs: get-project-name
@@ -69,4 +69,4 @@ jobs:
       - name: Run tests
         run: cargo test --locked --verbose
       - name: Clean Project
-        run: cargo clean --locked --project=${{ needs.get-project-name.outputs.name }}
+        run: cargo clean --locked --package=${{ needs.get-project-name.outputs.name }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,6 +45,27 @@ jobs:
           path: target
       - name: Build
         run: cargo build --verbose
+      - name: Clean Project
+        run: cargo clean --project=${{ needs.get-project-name.outputs.name }}
+  test:
+    name: Test Binary
+    needs: get-project-name
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Cache Registry
+        id: cache-registry
+        uses: actions/cache@v5
+        with:
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}-test
+          path: ~/.cargo
+      - name: Cache Dependency Builds
+        id: cache-deps
+        uses: actions/cache@v5
+        with:
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}-test-deps
+          path: target
       - name: Run tests
         run: cargo test --verbose
       - name: Clean Project

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Cache Registry
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
           path: ~/.cargo

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,18 +10,42 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  get-project-name:
+    name: Get Project Name
+    runs-on: ubuntu-22.04
+    outputs:
+      name: ${{ steps.get_name.outputs.name }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Get Name
+        id: get_name
+        run: |
+          NAME=$(cargo metadata --no-deps --format-version=1 | jq '.packages[] | .name' -r)
+          echo "name=$NAME" >> $GITHUB_OUTPUT
+
   build:
     name: Build Binary
+    needs: get-project-name
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Cache Registry
+        id: cache-registry
         uses: actions/cache@v5
         with:
           key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
           path: ~/.cargo
+      - name: Cache Dependency Builds
+        id: cache-deps
+        uses: actions/cache@v5
+        with:
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}-deps
+          path: target
       - name: Build
         run: cargo build --verbose
       - name: Run tests
         run: cargo test --verbose
+      - name: Clean Project
+        run: cargo clean --project=${{ needs.get-project-name.outputs.name }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   get-project-name:
-    name: Get Project Name
+    name: Get Package Name
     runs-on: ubuntu-22.04
     outputs:
       name: ${{ steps.get_name.outputs.name }}
@@ -24,8 +24,8 @@ jobs:
           NAME=$(cargo metadata --locked --no-deps --format-version=1 | jq '.packages[] | .name' -r)
           echo "name=$NAME" >> $GITHUB_OUTPUT
 
-  build:
-    name: Build Binary
+  build-and-test:
+    name: Build and Test Package
     needs: get-project-name
     runs-on: ubuntu-22.04
     steps:
@@ -45,28 +45,7 @@ jobs:
           path: target
       - name: Build
         run: cargo build --locked --verbose
-      - name: Clean Project
-        run: cargo clean --locked --package=${{ needs.get-project-name.outputs.name }}
-  test:
-    name: Test Binary
-    needs: get-project-name
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-      - name: Cache Registry
-        id: cache-registry
-        uses: actions/cache@v5
-        with:
-          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}-test
-          path: ~/.cargo
-      - name: Cache Dependency Builds
-        id: cache-deps
-        uses: actions/cache@v5
-        with:
-          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}-test-deps
-          path: target
-      - name: Run tests
+      - name: Test
         run: cargo test --locked --verbose
-      - name: Clean Project
+      - name: Clean Package
         run: cargo clean --locked --package=${{ needs.get-project-name.outputs.name }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,12 +11,17 @@ env:
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
-
+    name: Build Binary
+    runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v6
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Cache Registry
+        uses: actions/cache@v4
+        with:
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+          path: ~/.cargo
+      - name: Build
+        run: cargo build --verbose
+      - name: Run tests
+        run: cargo test --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Get Name
         id: get_name
         run: |
-          NAME=$(cargo metadata --no-deps --format-version=1 | jq '.packages[] | .name' -r)
+          NAME=$(cargo metadata --locked --no-deps --format-version=1 | jq '.packages[] | .name' -r)
           echo "name=$NAME" >> $GITHUB_OUTPUT
 
   build:
@@ -44,9 +44,9 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}-deps
           path: target
       - name: Build
-        run: cargo build --verbose
+        run: cargo build --locked --verbose
       - name: Clean Project
-        run: cargo clean --project=${{ needs.get-project-name.outputs.name }}
+        run: cargo clean --locked --project=${{ needs.get-project-name.outputs.name }}
   test:
     name: Test Binary
     needs: get-project-name
@@ -67,6 +67,6 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}-test-deps
           path: target
       - name: Run tests
-        run: cargo test --verbose
+        run: cargo test --locked --verbose
       - name: Clean Project
-        run: cargo clean --project=${{ needs.get-project-name.outputs.name }}
+        run: cargo clean --locked --project=${{ needs.get-project-name.outputs.name }}


### PR DESCRIPTION
This PR adds a workflow to automatically build and test the environment using ubuntu-22.04 containers. Caching happens for each Cargo.lock file hash so it re-fetches dependencies on a version change. Also automatically caches build artifacts of all dependencies as those don't change when no version change happens. It clears all project package contents before caching though so no (possibly corrupt) incremental build files stay in the cache.