### PR TITLE
refactor: move env vars to cargo config file

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,4 @@
+[env]
+# Local database schema for query macro features
+DATABASE_URL = "mysql://root@localhost:3306/herald"
+SQLX_OFFLINE = "true"

--- a/.env
+++ b/.env
@@ -1,3 +1,0 @@
-# Local database schema for query macro features
-DATABASE_URL=mysql://root@localhost:3306/herald
-SQLX_OFFLINE=true


### PR DESCRIPTION
In order to get rid of the `.env` file chaos I moved the build variables over to a cargo config file. Also should make it easier to state defaults for some commands.