### PR TITLE
feat: add data contract engine

### DIFF
--- a/sql/contracts/order_confirmation.sql
+++ b/sql/contracts/order_confirmation.sql
@@ -1,0 +1,5 @@
+SELECT events.title AS event_title, registrations.name AS registration_name, club_information.name_short AS club_sender, club_information.name_full AS club_name, registrations.status > 1 AS `approved: _`
+FROM registrations
+    JOIN events USING (event_id)
+    CROSS JOIN club_information
+WHERE registration_id = ?

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,6 +5,7 @@ use uuid::Uuid;
 pub(crate) mod intermediate;
 pub mod request;
 pub mod response;
+pub mod contract;
 
 use crate::Error;
 

--- a/src/types/contract.rs
+++ b/src/types/contract.rs
@@ -1,0 +1,23 @@
+use serde::Serialize;
+
+#[non_exhaustive]
+pub enum Contract {
+    OrderConfirmation(OrderConfirmation),
+}
+
+impl Contract {
+    pub fn into_inner(self) -> impl Serialize {
+        match self {
+            Self::OrderConfirmation(i) => i,
+        }
+    }
+}
+
+#[derive(Serialize)]
+pub struct OrderConfirmation {
+    pub event_title: String,
+    pub registration_name: String,
+    pub club_sender: String,
+    pub club_name: String,
+    pub approved: bool,
+}

--- a/src/types/contract.rs
+++ b/src/types/contract.rs
@@ -1,4 +1,11 @@
 use serde::Serialize;
+use sqlx::{
+    Database,
+    Executor,
+    Error,
+    MySql,
+};
+use uuid::Uuid;
 
 #[non_exhaustive]
 pub enum Contract {
@@ -6,11 +13,30 @@ pub enum Contract {
 }
 
 impl Contract {
+    pub async fn fetch<'e, E>(contract: &str, e: E, id: Uuid) -> Result<Self, Error>
+    where
+        E: Executor<'e, Database = MySql> + 'e
+    {
+        Ok(match contract {
+            "order_confirmation" => Self::OrderConfirmation(OrderConfirmation::fetch(e, id).await?),
+            _ => todo!(),
+        })
+    }
+
     pub fn into_inner(self) -> impl Serialize {
         match self {
             Self::OrderConfirmation(i) => i,
         }
     }
+}
+
+trait FromRegistration<DB>: Sized
+where
+    DB: Database,
+{
+    fn fetch<'e, E>(e: E, id: Uuid) -> impl Future<Output = Result<Self, Error>>
+    where
+        E: Executor<'e, Database = DB> + 'e;
 }
 
 #[derive(Serialize)]
@@ -20,4 +46,13 @@ pub struct OrderConfirmation {
     pub club_sender: String,
     pub club_name: String,
     pub approved: bool,
+}
+
+impl FromRegistration<MySql> for OrderConfirmation {
+    fn fetch<'e, E>(e: E, id: Uuid) -> impl Future<Output = Result<Self, Error>>
+    where
+        E: Executor<'e, Database = MySql> + 'e,
+    {
+        sqlx::query_file_as!(OrderConfirmation, "sql/contracts/order_confirmation.sql", id).fetch_one(e)
+    }
 }


### PR DESCRIPTION
Data contracts themselves are done, templating engine is still missing

EDIT: Technically, the contract engine is done with the implementation of `Contract::fetch`, since that matches any contract slug to an enum containing a serializable data contract. Templating itself is out of scope for this issue.

closes #10, closes #11, closes #13