### PR TITLE
docs: add more integration tests for registration workflow

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1,0 +1,295 @@
+{
+    "openapi": "3.2.0",
+    "info": {
+        "title": "Herald",
+        "summary": "Besiedlungszug Event Manager",
+        "description": "This API manages the events and registrations for the registered association `Historischer Besiedlungszug A.D. 1156`.",
+        "contact": {
+            "name": "Herald Issue Tracker",
+            "url": "https://github.com/besiedlungszug/herald/issues"
+        },
+        "license": {
+            "name": "Apache 2.0",
+            "identifier": "Apache-2.0"
+        },
+        "version": "0.1.0"
+    },
+    "servers": [{
+        "url": "https://limbus.davidlokison.com/herald/dev",
+        "description": "Herald backend service hosted on DavidLokison's personal cloud server",
+        "name": "limbus"
+    }],
+    "paths": {
+        "/health": {
+            "get": {
+                "summary": "Check Upstream Health",
+                "description": "This operation runs a small selection of tests on the database backend and responds with test status and response time.",
+                "operationId": "checkHealth",
+                "responses": {
+                    "200": {
+                        "summary": "Successful Health Check",
+                        "content": { "application/json": { "$ref": "#/components/mediaTypes/UpstreamHealth" } }
+                    },
+                    "default": { "$ref": "#/components/responses/Error" }
+                }
+            }
+        },
+        "/events/open": {
+            "get": {
+                "summary": "Get Open Events",
+                "description": "This query responds with a list of all association events currently up for registration.",
+                "operationId": "getOpenEvents",
+                "responses": {
+                    "200": {
+                        "summary": "Retrieved Event List",
+                        "content": { "application/json": { "$ref": "#/components/mediaTypes/Events" } }
+                    },
+                    "default": { "$ref": "#/components/responses/Error" }
+                }
+            }
+        },
+        "/events/types": {
+            "get": {
+                "summary": "Get Event Types",
+                "description": "This query responds with a list of available event types.",
+                "operationId": "getEventTypes",
+                "responses": {
+                    "200": {
+                        "summary": "Retrieved Event Types",
+                        "content": { "application/json": { "$ref": "#/components/mediaTypes/EventTypes" } }
+                    },
+                    "default": { "$ref": "#/components/responses/Error" }
+                }
+            }
+        },
+        "/events/types/{eventType}/items": {
+            "get": {
+                "summary": "Get Bookable Items",
+                "description": "This query responds with a list of bookable items the event type supports",
+                "operationId": "getBookableItems",
+                "parameters": [
+                    { "$ref": "#/components/parameters/eventType" }
+                ],
+                "responses": {
+                    "200": {
+                        "summary": "Retrieved Articles",
+                        "content": { "application/json": { "$ref": "#/components/mediaTypes/Articles" } }
+                    },
+                    "default": { "$ref": "#/components/responses/Error" }
+                }
+            }
+        },
+        "/events/{eventId}/registrations/preview": {
+            "get": {
+                "summary": "Get Registration Preview",
+                "description": "This query responds with a list of articles corresponding to the persons queried in the same order as the persons supplied",
+                "operationId": "getRegistrationPreview",
+                "parameters": [
+                    { "$ref": "#/components/parameters/eventId" }, {
+                        "name": "birthdays",
+                        "in": "query",
+                        "description": "A list of the persons' birthdays to query article data for",
+                        "required": true,
+                        "explode": true,
+                        "schema": { "type": "string", "format": "date" }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "summary": "Retrieved Articles",
+                        "content": { "application/json": { "$ref": "#/components/mediaTypes/Articles" } }
+                    },
+                    "default": { "$ref": "#/components/responses/Error" }
+                }
+            }
+        },
+        "/events/{eventId}/registrations": {
+            "post": {
+                "summary": "Create Registration",
+                "description": "This request creates a registration to the specified event",
+                "operationId": "createRegistration",
+                "parameters": [
+                    { "$ref": "#/components/parameters/eventId" }, {
+                        "name": "manual",
+                        "in": "query",
+                        "description": "Request manual registration handling instead of automatic approval",
+                        "schema": { "type": "boolean" }
+                    }, {
+                        "name": "registration",
+                        "in": "data",
+                        "description": "Requested registration data",
+                        "required": true,
+                        "schema": { "$ref": "#/components/schemas/RegistrationRequest" }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "summary": "Registration Succeeded",
+                        "content": {}
+                    },
+                    "default": { "$ref": "#/components/responses/Error" }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "UpstreamHealth": {
+                "type": "object",
+                "required": ["ping", "tests"],
+                "properties": {
+                    "ping": { "type": "number", "format": "float" },
+                    "tests": { "type": "array" }
+                }
+            },
+            "Address": {
+                "type": "object",
+                "required": ["street", "zip", "city"],
+                "properties": {
+                    "street": { "type": "string", "example": "Musterstraße 15" },
+                    "zip": { "type": "string", "example": "12345" },
+                    "city": { "type": "string", "example": "Musterhausen" }
+                }
+            },
+            "Name": {
+                "type": "object",
+                "required": ["title", "firstname", "lastname"],
+                "properties": {
+                    "title": { "type": "string", "example": "Frau" },
+                    "firstname": { "type": "string", "example": "Klara" },
+                    "lastname": { "type": "string", "example": "Mustermann" }
+                }
+            },
+            "Price": {
+                "type": "object",
+                "required": ["value", "decimals", "currency"],
+                "properties": {
+                    "value": { "type": "number", "format": "int", "example": 3000 },
+                    "decimals": { "type": "number", "format": "int", "example": 2 },
+                    "currency": { "type": "string", "example": "EUR" }
+                }
+            },
+            "EmergencyContact": {
+                "type": "object",
+                "required": ["name", "phone"],
+                "properties": {
+                    "name": { "type": "string", "example": "Max Mustermann" },
+                    "phone": { "type": "string", "example": "+49 123 4567890" }
+                }
+            },
+            "PersonFoodOptions": {
+                "type": "object",
+                "required": ["vegetarian"],
+                "properties": {
+                    "vegetarian": { "type": "boolean" }
+                }
+            },
+            "Event": {
+                "type": "object",
+                "required": ["id", "type", "title", "begin", "end"],
+                "properties": {
+                    "id": { "type": "string", "format": "uuid" },
+                    "type": { "type": "string" },
+                    "title": { "type": "string" },
+                    "begin": { "type": "string", "format": "date" },
+                    "end": { "type": "string", "format": "date" },
+                    "description": { "type": "string" }
+                }
+            },
+            "Article": {
+                "type": "object",
+                "required": ["id", "description", "price"],
+                "properties": {
+                    "id": { "type": "string" },
+                    "description": { "type": "string" },
+                    "price": { "$ref": "#/components/schemas/Price" }
+                }
+            },
+            "RegistrationRequest": {
+                "type": "object",
+                "required": ["name", "address", "phone", "email", "comment", "emergency", "persons", "items"],
+                "properties": {
+                    "name": { "$ref": "#/components/schemas/Name" },
+                    "address": { "$ref": "#/components/schemas/Address" },
+                    "phone": { "type": "string" },
+                    "email": { "type": "string" },
+                    "comment": { "type": "string" },
+                    "emergency": { "$ref": "#/components/schemas/EmergencyContact" },
+                    "persons": { "type": "array", "items": { "$ref": "#/components/schemas/PersonRequest" } },
+                    "items": { "type": "array", "items": { "$ref": "#/components/schemas/ItemRequest" } }
+                }
+            },
+            "PersonRequest": {
+                "type": "object",
+                "required": ["name", "address", "birthday", "comment", "foodOptions"],
+                "properties": {
+                    "name": { "$ref": "#/components/schemas/Name" },
+                    "address": { "$ref": "#/components/schemas/Address" },
+                    "birthday": { "type": "string", "format": "date" },
+                    "comment": { "type": "string" },
+                    "foodOptions": { "$ref": "#/components/schemas/PersonFoodOptions" }
+                }
+            },
+            "ItemRequest": {
+                "type": "object",
+                "required": ["articleId", "comment"],
+                "properties": {
+                    "articleId": { "type": "string" },
+                    "comment": { "type": "string" }
+                }
+            }
+        },
+        "responses": {
+            "Error": {
+                "summary": "Unexpected Error",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "required": ["error", "message"],
+                            "properties": {
+                                "error": { "type": "string" },
+                                "message": { "type": "string" }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "parameters": {
+            "eventType": {
+                "name": "eventType",
+                "in": "path",
+                "description": "Event Type to query items from (see `/events/types`)",
+                "required": true,
+                "schema": { "type": "string" },
+                "example": "hbz"
+            },
+            "eventId": {
+                "name": "eventId",
+                "in": "path",
+                "description": "Event ID to do actions on (see `/events/open`)",
+                "required": true,
+                "schema": { "type": "string", "format": "uuid" }
+            }
+        },
+        "mediaTypes": {
+            "UpstreamHealth": { "schema": {
+                "type": "object",
+                "properties": { "data": { "$ref": "#/components/schemas/UpstreamHealth" } }
+            } },
+            "Events": { "schema": {
+                "type": "object",
+                "properties": { "data": { "type": "array", "items": { "$ref": "#/components/schemas/Event" } } }
+            } },
+            "EventTypes": { "schema": {
+                "type": "object",
+                "properties": { "data": { "type": "array", "items": { "type": "string" } } }
+            } },
+            "Articles": { "schema": {
+                "type": "object",
+                "properties": { "data": { "type": "array", "items": { "$ref": "#/components/schemas/Article" } } }
+            } }
+        }
+    }
+}

--- a/tests/common/create_open_event.sql
+++ b/tests/common/create_open_event.sql
@@ -1,10 +1,10 @@
 INSERT INTO events (
     event_type_slug,
     title,
-    begin_date,
+    start_date
 )
 VALUES (
     "hbz",
     "Test Event",
-    DATE_ADD(CURRENT_DATE INTERVAL 2 WEEK),
+    DATE_ADD(CURRENT_DATE, INTERVAL 2 WEEK)
 )

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,5 +1,7 @@
 #![allow(unused)]
 
+use std::thread;
+use std::time::Duration;
 use testcontainers::{
     Container,
     GenericImage,
@@ -20,8 +22,14 @@ pub struct SqlServerContainer(Container<GenericImage>);
 
 impl SqlServerContainer {
     pub fn create_open_event(&self) {
-        self.0.exec(ExecCommand::new(vec!["dolt", "sql", "-q", include_str!("create_open_event.sql")]))
+        let mut result = self.0.exec(ExecCommand::new(vec!["dolt", "sql", "-q", include_str!("create_open_event.sql")]))
             .expect("Failed to create open event");
+        let mut buf = String::new();
+        result.stdout().read_to_string(&mut buf);
+        result.stderr().read_to_string(&mut buf);
+        println!("> dolt sql -q <create_open_event>");
+        println!("{}", buf);
+        println!("<<<");
     }
 }
 
@@ -32,7 +40,7 @@ pub struct TestSuite {
 
 impl TestSuite {
     pub fn spawn() -> Self {
-        let sql_server = GenericImage::new("besiedlungszug/herald-sql-server", "0.3.0")
+        let sql_server = GenericImage::new("besiedlungszug/herald-sql-server", "0.3.4")
             .with_wait_for(WaitFor::message_on_stdout("Ready for connections."))
             .with_network("herald")
             .with_env_var("DOLT_ROOT_HOST", "%")

--- a/tests/envelope.rs
+++ b/tests/envelope.rs
@@ -1,5 +1,6 @@
 mod common;
 
+use std::assert_matches;
 use rocket::serde::json::{from_str, Value};
 use serde::Deserialize;
 use crate::common::TestSuite;
@@ -14,13 +15,18 @@ struct Error {
 #[test]
 fn success_endpoint_has_data() {
     let suite = TestSuite::spawn();
-    let response = reqwest::blocking::get(suite.path("/events/open")).unwrap();
+    let response = reqwest::blocking::get(suite.path("/events/open"))
+        .expect("Rocket should be responsive by now");
     assert_eq!(response.status(), reqwest::StatusCode::OK);
     assert_eq!(response.headers().get(reqwest::header::CONTENT_TYPE).unwrap(), "application/json");
-    let text = response.text().unwrap();
-    let payload: Value = from_str(&text).unwrap();
-    assert!(payload.is_object());
-    assert!(payload.as_object().unwrap().contains_key("data"));
+    let response_text = response.text();
+    assert_matches!(response_text, Ok(_));
+    let response_text = response_text.unwrap();
+    let response_payload: Result<Value, _> = from_str(&response_text);
+    assert_matches!(response_payload, Ok(_));
+    let response_payload = response_payload.unwrap();
+    assert!(response_payload.is_object());
+    assert!(response_payload.as_object().unwrap().contains_key("data"));
 }
 
 #[test]

--- a/tests/registration-flow.rs
+++ b/tests/registration-flow.rs
@@ -55,7 +55,7 @@ fn registration_preview_succeeds() {
         .as_object().unwrap()
         .get("id").unwrap()
         .as_str().unwrap();
-    let preview_query = format!("/events/{}/registrations/preview?[].birthday=1974-05-19&[].birthday=1975-08-31", event_id);
+    let preview_query = format!("/events/{}/registrations/preview?birthdays=1974-05-19&birthdays=1975-08-31", event_id);
     let response = reqwest::blocking::get(suite.path(&preview_query)).unwrap();
     assert_eq!(response.status(), reqwest::StatusCode::OK);
     let response_text = response.text().unwrap();

--- a/tests/registration-flow.rs
+++ b/tests/registration-flow.rs
@@ -1,12 +1,72 @@
 mod common;
 
+use std::assert_matches;
+use rocket::serde::json::{Value, from_str};
+use uuid::Uuid;
 use crate::common::TestSuite;
 
 #[test]
 fn get_open_events_succeeds() {
     let suite = TestSuite::spawn();
     suite.sql_server.create_open_event();
-    let response = reqwest::blocking::get(suite.path("/events/open"))
-        .expect("Rocket should be responsive by now");
+    let response = reqwest::blocking::get(suite.path("/events/open")).unwrap();
     assert_eq!(response.status(), reqwest::StatusCode::OK);
+    let response_text = response.text().unwrap();
+    println!("{}", &response_text);
+    let response_payload: Value = from_str(&response_text).unwrap();
+    let response_data = response_payload.get("data").unwrap();
+    assert!(response_data.is_array());
+    let response_data = response_data.as_array().unwrap();
+    assert_eq!(response_data.len(), 1);
+    let event_data = &response_data[0];
+    assert!(event_data.is_object());
+    let event_data = event_data.as_object().unwrap();
+    assert!(event_data.contains_key("id"));
+    let event_id = event_data.get("id").unwrap();
+    assert!(event_id.is_string());
+    let event_id = event_id.as_str().unwrap();
+    assert_matches!(Uuid::try_parse(event_id), Ok(_));
+}
+
+#[test]
+fn get_open_events_empty_array() {
+    let suite = TestSuite::spawn();
+    let response = reqwest::blocking::get(suite.path("/events/open")).unwrap();
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    let response_text = response.text().unwrap();
+    println!("{}", &response_text);
+    let response_payload: Value = from_str(&response_text).unwrap();
+    let response_data = response_payload.get("data").unwrap();
+    assert!(response_data.is_array());
+    let response_data = response_data.as_array().unwrap();
+    assert_eq!(response_data.len(), 0);
+}
+
+#[test]
+fn registration_preview_succeeds() {
+    let suite = TestSuite::spawn();
+    suite.sql_server.create_open_event();
+    let response = reqwest::blocking::get(suite.path("/events/open")).unwrap();
+    let response_text = response.text().unwrap();
+    println!("{}", &response_text);
+    let response_payload: Value = from_str(&response_text).unwrap();
+    let event_id = response_payload.get("data").unwrap()
+        .as_array().unwrap()[0]
+        .as_object().unwrap()
+        .get("id").unwrap()
+        .as_str().unwrap();
+    let preview_query = format!("/events/{}/registrations/preview?[].birthday=1974-05-19&[].birthday=1975-08-31", event_id);
+    let response = reqwest::blocking::get(suite.path(&preview_query)).unwrap();
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    let response_text = response.text().unwrap();
+    println!("{}", &response_text);
+    let response_payload: Value = from_str(&response_text).unwrap();
+    let response_data = response_payload.get("data").unwrap();
+    assert!(response_data.is_array());
+    let response_data = response_data.as_array().unwrap();
+    assert_eq!(response_data.len(), 2);
+    for article_data in response_data {
+        assert!(article_data.is_object());
+        assert!(article_data.as_object().unwrap().contains_key("price"));
+    }
 }


### PR DESCRIPTION
This PR fixes the test behaviour for the common test suite module (by actually making the sql file syntactically correct, it just failed silently now) in addition to adding a bunch of new integration test cases (which was the reason that errorneous behaviour bubbled to the surface in the first place).

### New Integration Tests
- `registration-flow::get_open_events_empty_array`, which is what Open Events Succeeds formerly was, but actually checking against the array being empty if there are no events in the database.
- `registration-flow::registration_preview_succeeds`, which checks for the correct response envelope for a given preview query with a bunch of hardcoded birthdays that are bound to be made parametric further.

### Updated Integration Tests
- `registration-flow::get_open_events_succeeds` doesn't care now about the test suite being responsive, that is handled elsewhere; also checks for the actual existance of a returned event object with its id.
- `envelope::success_endpoint_has_data` now handles the existance of an actual data key inside the JSON object returned, also this is the endpoint with the expect clause to say that the binary should be responsive. Other tests will fail with an unwrap, but if that's the case, then this test will fail too and give the actual error message.

### Known Issues
Well, the current state does not run every test case successfully. As I was redesigning the API mid-refactor (which is a *perfect* time to do this... _sigh_), I had to first adapt the test cases and then make an issue out of the non-running tests. Known to fail: `registration-flow::registration_preview_succeeds`