### PR TITLE
feat: `create_registration` now uses the `manual` flag to turn off automatic approval

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -2,7 +2,7 @@ name: herald
 
 services:
   sql:
-    image: besiedlungszug/herald-sql-server:0.3.0
+    image: besiedlungszug/herald-sql-server:0.4.0
     environment:
       DOLT_DATABASE: "herald"
       DOLT_USER: "user"

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -96,8 +96,8 @@
                 ],
                 "responses": {
                     "200": {
-                        "summary": "Retrieved Articles",
-                        "content": { "application/json": { "$ref": "#/components/mediaTypes/Articles" } }
+                        "summary": "Retrieved Prices",
+                        "content": { "application/json": { "$ref": "#/components/mediaTypes/Prices" } }
                     },
                     "default": { "$ref": "#/components/responses/Error" }
                 }
@@ -161,8 +161,9 @@
             },
             "Price": {
                 "type": "object",
-                "required": ["value", "decimals", "currency"],
+                "required": ["description", "value", "decimals", "currency"],
                 "properties": {
+                    "description": { "type": "string" },
                     "value": { "type": "number", "format": "int", "example": 3000 },
                     "decimals": { "type": "number", "format": "int", "example": 2 },
                     "currency": { "type": "string", "example": "EUR" }
@@ -196,13 +197,13 @@
                 }
             },
             "Article": {
-                "type": "object",
-                "required": ["id", "description", "price"],
-                "properties": {
-                    "id": { "type": "string" },
-                    "description": { "type": "string" },
-                    "price": { "$ref": "#/components/schemas/Price" }
-                }
+                "allOf": [{
+                    "type": "object",
+                    "required": ["id"],
+                    "properties": { "id": { "type": "string" } }
+                }, {
+                    "$ref": "#/components/schemas/Price"
+                }]
             },
             "RegistrationRequest": {
                 "type": "object",
@@ -288,6 +289,10 @@
             "Articles": { "schema": {
                 "type": "object",
                 "properties": { "data": { "type": "array", "items": { "$ref": "#/components/schemas/Article" } } }
+            } },
+            "Prices": { "schema": {
+                "type": "object",
+                "properties": { "data": { "type": "array", "items": { "$ref": "#/components/schemas/Price" } } }
             } }
         }
     }

--- a/sql/events/registrations/00_checkup.sql
+++ b/sql/events/registrations/00_checkup.sql
@@ -1,18 +1,27 @@
 WITH
-    map AS (SELECT article_id, policy_birthday FROM article_policy_map_persons WHERE event_id = ?)
-SELECT HEX(article_id) AS id, a.description, price
-FROM JSON_TABLE(
+    params AS (SELECT event_id FROM events WHERE event_id = ?),
+    data AS (SELECT * FROM JSON_TABLE(
         ?, "$[*]" COLUMNS(
             ord FOR ORDINALITY,
             birthday DATE PATH "$" ERROR ON ERROR
         )
-    ) data
-    INNER JOIN LATERAL (
+    ) data),
+    map_week AS (SELECT article_id, max_birthday FROM params INNER JOIN event_age_groups USING (event_id) WHERE article_type = "week"),
+    map_disc AS (SELECT article_id, max_birthday FROM params INNER JOIN event_age_groups USING (event_id) INNER JOIN event_discounts USING (event_id, article_type)),
+    data_week AS (SELECT ord, description, price FROM data INNER JOIN LATERAL (
         SELECT article_id
-        FROM map
-        WHERE policy_birthday >= birthday
-        ORDER BY policy_birthday ASC
+        FROM map_week
+        WHERE max_birthday >= birthday
+        ORDER BY max_birthday ASC
         LIMIT 1
-    ) m
-    INNER JOIN articles a USING (article_id)
+    ) m INNER JOIN articles a USING (article_id)),
+    data_disc AS (SELECT ord, description, price FROM data INNER JOIN LATERAL (
+        SELECT article_id
+        FROM map_disc
+        WHERE max_birthday >= birthday
+        ORDER BY max_birthday ASC
+        LIMIT 1
+    ) m INNER JOIN articles a USING (article_id))
+SELECT CONCAT(data_week.description, COALESCE(CONCAT(', ', data_disc.description), "")) AS description, data_week.price + COALESCE(data_disc.price, 0) AS `price: _`
+FROM data_week LEFT JOIN data_disc USING (ord)
 ORDER BY ord

--- a/sql/events/registrations/04_finish.sql
+++ b/sql/events/registrations/04_finish.sql
@@ -2,6 +2,6 @@ UPDATE registrations
 SET status = (
     SELECT status
     FROM registration_statuses
-    WHERE status_slug = "awaiting_approval"
+    WHERE status_slug = ?
 )
 WHERE registration_id = @RegistrationId

--- a/sql/events/registrations/05_approve.sql
+++ b/sql/events/registrations/05_approve.sql
@@ -1,0 +1,1 @@
+CALL approve_registration(@RegistrationId)

--- a/src/data.rs
+++ b/src/data.rs
@@ -46,10 +46,10 @@ pub async fn get_registration_preview(e: &mut MySqlConnection, event_id: &EventI
     Ok(articles)
 }
 
-pub async fn create_registration(e: &mut MySqlConnection, event_id: &EventId<'_>, registration: &NewRegistration<'_>) -> Result<()> {
+pub async fn create_registration(e: &mut MySqlConnection, event_id: &EventId<'_>, registration: &NewRegistration<'_>, manual: bool) -> Result<()> {
     sqlx::query_file!("sql/events/registrations/01_begin.sql", **event_id, registration.as_json()).execute(&mut *e).await?;
     sqlx::query_file!("sql/events/registrations/02_persons.sql", registration.persons.as_json()).execute(&mut *e).await?;
     sqlx::query_file!("sql/events/registrations/03_items.sql", registration.items.as_json()).execute(&mut *e).await?;
-    sqlx::query_file!("sql/events/registrations/04_finish.sql").execute(e).await?;
+    sqlx::query_file!("sql/events/registrations/04_finish.sql", if manual { "awaiting_approval" } else { "automatic_approval" }).execute(e).await?;
     Ok(())
 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -50,6 +50,11 @@ pub async fn create_registration(e: &mut MySqlConnection, event_id: &EventId<'_>
     sqlx::query_file!("sql/events/registrations/01_begin.sql", **event_id, registration.as_json()).execute(&mut *e).await?;
     sqlx::query_file!("sql/events/registrations/02_persons.sql", registration.persons.as_json()).execute(&mut *e).await?;
     sqlx::query_file!("sql/events/registrations/03_items.sql", registration.items.as_json()).execute(&mut *e).await?;
-    sqlx::query_file!("sql/events/registrations/04_finish.sql", if manual { "awaiting_approval" } else { "automatic_approval" }).execute(e).await?;
+    if manual {
+        sqlx::query_file!("sql/events/registrations/04_finish.sql", "awaiting_approval").execute(e).await?;
+    } else {
+        sqlx::query_file!("sql/events/registrations/04_finish.sql", "automatic_approval").execute(&mut *e).await?;
+        sqlx::query_file!("sql/events/registrations/05_approve.sql").execute(e).await?;
+    }
     Ok(())
 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -39,8 +39,8 @@ pub async fn get_open_events(e: &mut MySqlConnection) -> Result<Vec<Event>> {
         .map_err(Into::into)
 }
 
-pub async fn get_registration_preview(e: &mut MySqlConnection, event_id: &EventId<'_>, birthdays: &Vec<Date>) -> Result<Vec<Article>> {
-    let articles = sqlx::query_file_as!(intermediate::Article, "sql/events/registrations/00_checkup.sql", **event_id, birthdays.as_json()).fetch_all(e).await?;
+pub async fn get_registration_preview(e: &mut MySqlConnection, event_id: &EventId<'_>, birthdays: &Vec<Date>) -> Result<Vec<Price>> {
+    let articles = sqlx::query_file_as!(intermediate::PricePreview, "sql/events/registrations/00_checkup.sql", **event_id, birthdays.as_json()).fetch_all(e).await?;
     // TODO: attach actual price info
     let articles = articles.into_iter().map(|a| a.with_price_info(2, "EUR".to_string())).collect();
     Ok(articles)

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ async fn get_bookable_items(mut db: Connection<Herald>, event_type_slug: &str) -
 }
 
 #[get("/events/<event_id>/registrations/preview?<birthdays>")]
-async fn get_registration_preview(mut db: Connection<Herald>, event_id: Uuid, birthdays: Vec<Date>) -> Result<Json<Vec<Article>>> {
+async fn get_registration_preview(mut db: Connection<Herald>, event_id: Uuid, birthdays: Vec<Date>) -> Result<Json<Vec<Price>>> {
     let event_id = EventId::try_query(&mut **db, &event_id).await?;
     let preview = herald::data::get_registration_preview(&mut db, &event_id, &birthdays).await?;
     Envelope::ok(preview)

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,10 +30,10 @@ async fn get_registration_preview(mut db: Connection<Herald>, event_id: Uuid, bi
     Envelope::ok(preview)
 }
 
-#[post("/events/<event_id>/registrations", data = "<registration>")]
-async fn create_registration(mut db: Connection<Herald>, event_id: Uuid, registration: Json<NewRegistration<'_>>) -> Result<Json<Created<()>>> {
+#[post("/events/<event_id>/registrations?<manual>", data = "<registration>")]
+async fn create_registration(mut db: Connection<Herald>, event_id: Uuid, manual: bool, registration: Json<NewRegistration<'_>>) -> Result<Json<Created<()>>> {
     let event_id = EventId::try_query(&mut **db, &event_id).await?;
-    let _ = data::create_registration(&mut db, &event_id, &registration).await?;
+    let _ = data::create_registration(&mut db, &event_id, &registration, manual).await?;
     Envelope::created("", ()) // TODO
 }
 

--- a/src/types/intermediate.rs
+++ b/src/types/intermediate.rs
@@ -96,18 +96,34 @@ pub struct NewRegistration<'r> {
 
 
 
+pub struct PricePreview {
+    pub description: String,
+    pub price: i32,
+}
+
+impl PricePreview {
+    pub fn with_price_info(self, decimals: u8, currency: String) -> response::Price {
+        response::Price {
+            description: self.description,
+            value: self.price,
+            decimals: decimals,
+            currency: currency,
+        }
+    }
+}
+
 pub struct Article {
     pub id: String,
     pub description: String,
-    pub price: u32,
+    pub price: i32,
 }
 
 impl Article {
     pub fn with_price_info(self, decimals: u8, currency: String) -> response::Article {
         response::Article {
             id: self.id,
-            description: self.description,
             price: response::Price {
+                description: self.description,
                 value: self.price,
                 decimals: decimals,
                 currency: currency,

--- a/src/types/response.rs
+++ b/src/types/response.rs
@@ -4,7 +4,8 @@ use uuid::Uuid;
 
 #[derive(Serialize, Debug)]
 pub struct Price {
-    pub value: u32,
+    pub description: String,
+    pub value: i32,
     pub decimals: u8,
     pub currency: String,
 }
@@ -28,7 +29,7 @@ pub struct Event {
 #[derive(Serialize, Debug)]
 pub struct Article {
     pub id: String,
-    pub description: String,
+    #[serde(flatten)]
     pub price: Price,
 }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -40,7 +40,7 @@ pub struct TestSuite {
 
 impl TestSuite {
     pub fn spawn() -> Self {
-        let sql_server = GenericImage::new("besiedlungszug/herald-sql-server", "0.3.4")
+        let sql_server = GenericImage::new("besiedlungszug/herald-sql-server", "0.4.0")
             .with_wait_for(WaitFor::message_on_stdout("Ready for connections."))
             .with_network("herald")
             .with_env_var("DOLT_ROOT_HOST", "%")


### PR DESCRIPTION
This optional flag can be specified either as `?manual` or `?manual=true` or other things the HTTP standard recognizes as truthy values. It skips automatic approval and uses a special status for `awaiting_approval` so that templates also know that it was not automatically approved and has to be edited manually.

closes #40 