### PR TITLE
clean: remove unneeded container and test runs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,8 +1,6 @@
 name: Rust
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -10,12 +10,3 @@ services:
       DOLT_USER_HOST: "%"
     ports:
       - "3306:3306"
-  smtp:
-    image: axllent/mailpit:v1.30
-    environment:
-      MP_SMTP_REQUIRE_TLS: "true"
-      MP_SMTP_TLS_CERT: "sans:localhost"
-      MP_SMTP_TLS_KEY: "sans:localhost"
-    ports:
-      - "1025:1025"
-      - "8025:8025"


### PR DESCRIPTION
I took the liberty of reverting the addition of a new container I introduced, cause we probably won't need it in the main repo. Gonna use it in a different mailer repo maybe. Also build/test should only run on new pull requests cause we have a branch rule on that one either way.